### PR TITLE
Fix file listing to not use a generator

### DIFF
--- a/src/data_loading/data_loading.py
+++ b/src/data_loading/data_loading.py
@@ -27,9 +27,9 @@ precip_cfsr_path = DATA_DIR / "CFSR" / "CFSR_APCP_Basin_Avgs.csv"
 # CFS
 cfs_dir = DATA_DIR / "CFS"
 
-temp_cfs_path = cfs_dir.glob("*/CFS_TMP_Basin_Avgs.csv")
-precip_cfs_path = cfs_dir.glob("*/CFS_APCP_Basin_Avgs.csv")
-evap_cfs_path = cfs_dir.glob("*/CFS_EVAP_Basin_Avgs.csv")
+temp_cfs_path = list(cfs_dir.glob("*/CFS_TMP_Basin_Avgs.csv"))
+precip_cfs_path = list(cfs_dir.glob("*/CFS_APCP_Basin_Avgs.csv"))
+evap_cfs_path = list(cfs_dir.glob("*/CFS_EVAP_Basin_Avgs.csv"))
 
 
 # L2SWBM


### PR DESCRIPTION
Super easy fix - I found a bug. Basically, `cfs_dir.glob` returns a generator, which becomes an empty list. So this code only worked the first time you ran it.

That's been fixed, you can now run load_data multiple times without causing an issue.